### PR TITLE
Add random computer player

### DIFF
--- a/gin_rummy.py
+++ b/gin_rummy.py
@@ -131,16 +131,18 @@ class GinRummyGame:
             player = self.players[current]
             opponent = self.players[1 - current]
 
-            # draw from deck for simplicity
             if not self.deck.cards:
                 # no cards left means the round ends in a draw
                 return None
-            drawn = self.deck.draw()
-            player.hand.add_card(drawn)
 
-            # discard random card for demonstration
-            discard = random.choice(player.hand.cards)
-            player.discard(discard, self.discard_pile)
+            if hasattr(player, "play_turn"):
+                player.play_turn(self)
+            else:
+                # default random action
+                drawn = self.deck.draw()
+                player.hand.add_card(drawn)
+                discard = random.choice(player.hand.cards)
+                player.discard(discard, self.discard_pile)
 
             if player.hand.is_gin():
                 return player
@@ -151,7 +153,9 @@ class GinRummyGame:
 
 if __name__ == '__main__':
     random.seed(42)
-    players = [Player('A'), Player('B')]
+    from random_player import RandomPlayer
+
+    players = [RandomPlayer('A'), RandomPlayer('B')]
     game = GinRummyGame(players)
     winner = game.play_round()
     if winner:

--- a/random_player.py
+++ b/random_player.py
@@ -1,0 +1,20 @@
+import random
+from gin_rummy import Player
+
+class RandomPlayer(Player):
+    """Player that makes random legal moves with no strategy."""
+
+    def play_turn(self, game):
+        """Perform a random legal turn in the given ``GinRummyGame``."""
+        draw_from_discard = bool(game.discard_pile) and random.choice([True, False])
+        if draw_from_discard:
+            drawn = game.discard_pile.pop()
+            self.hand.add_card(drawn)
+            discard_options = [c for c in self.hand.cards if c is not drawn]
+        else:
+            drawn = game.deck.draw()
+            self.hand.add_card(drawn)
+            discard_options = self.hand.cards
+
+        discard = random.choice(discard_options)
+        self.discard(discard, game.discard_pile)


### PR DESCRIPTION
## Summary
- implement `RandomPlayer` that draws and discards randomly
- let `GinRummyGame.play_round` call `play_turn` if present
- default demo now uses `RandomPlayer`

## Testing
- `python3 -m py_compile gin_rummy.py random_player.py`
- `python3 gin_rummy.py | head -n 1`

------
https://chatgpt.com/codex/tasks/task_e_684d2e78c7d88332b0fcd368937f9a90