### PR TITLE
Add meld and sort options to web UI

### DIFF
--- a/gin_rummy.py
+++ b/gin_rummy.py
@@ -101,6 +101,7 @@ class Player:
     def __init__(self, name: str):
         self.name = name
         self.hand = Hand()
+        self.melds: List[List[Card]] = []  # cards the player has laid down
 
     def draw(self, source: List[Card]):
         card = source.pop()


### PR DESCRIPTION
## Summary
- track melds laid down by players
- provide helpers to validate and list possible melds
- display melds and allow laying them down
- allow sorting the human hand via the UI

## Testing
- `python3 -m py_compile gin_rummy.py random_player.py web_ui.py`


------
https://chatgpt.com/codex/tasks/task_e_684d3230393c83328b90c9dd2bb86eaa