### PR TITLE
Add colored card output

### DIFF
--- a/gin_rummy.py
+++ b/gin_rummy.py
@@ -23,6 +23,23 @@ class Card:
         symbol = Card.SUIT_SYMBOLS[self.suit]
         return f'{r}{symbol}'
 
+    def colored(self) -> str:
+        """Return an ANSI colored representation of the card."""
+        names = {1: 'A', 11: 'J', 12: 'Q', 13: 'K'}
+        r = names.get(self.rank, str(self.rank))
+        symbol = Card.SUIT_SYMBOLS[self.suit]
+        if self.suit in ('D', 'H'):
+            return f"\033[31m{r}{symbol}\033[0m"
+        return f"{r}{symbol}"
+
+    def to_html(self) -> str:
+        """Return an HTML representation of the card with color styling."""
+        names = {1: 'A', 11: 'J', 12: 'Q', 13: 'K'}
+        r = names.get(self.rank, str(self.rank))
+        symbol = Card.SUIT_SYMBOLS[self.suit]
+        color = 'red' if self.suit in ('D', 'H') else 'black'
+        return f'<span style="color:{color}">{r}{symbol}</span>'
+
 class Deck:
     def __init__(self):
         self.cards = [Card(rank, suit) for suit in Card.SUITS for rank in Card.RANKS]
@@ -48,6 +65,10 @@ class Hand:
 
     def __repr__(self):
         return ' '.join(map(str, self.cards))
+
+    def colored(self) -> str:
+        """Return a string representation using ANSI colors."""
+        return ' '.join(c.colored() for c in self.cards)
 
     def score_deadwood(self) -> int:
         """Return the total pip value of unmatched cards."""
@@ -205,6 +226,6 @@ if __name__ == '__main__':
     game = GinRummyGame(players)
     winner = game.play_round()
     if winner:
-        print(f'{winner.name} wins with hand: {winner.hand}')
+        print(f'{winner.name} wins with hand: {winner.hand.colored()}')
     else:
         print('Round ended in a draw.')

--- a/web_ui.py
+++ b/web_ui.py
@@ -53,21 +53,22 @@ def redirect(start_response, location="/"):
 
 
 def html_page(message=""):
-    top_discard = GAME.discard_pile[-1] if GAME.discard_pile else "None"
-    hand = " ".join(str(c) for c in HUMAN.hand.cards)
+    top_discard = GAME.discard_pile[-1] if GAME.discard_pile else None
+    hand = " ".join(c.to_html() for c in HUMAN.hand.cards)
     deck_count = len(GAME.deck.cards)
 
     html = ["<html><body>"]
     html.append(f"<h2>Your hand: {hand}</h2>")
     if HUMAN.melds:
         for meld in HUMAN.melds:
-            meld_str = " ".join(str(c) for c in meld)
+            meld_str = " ".join(c.to_html() for c in meld)
             html.append(f"<p>Meld: {meld_str}</p>")
     if COMPUTER.melds:
         for meld in COMPUTER.melds:
-            meld_str = " ".join(str(c) for c in meld)
+            meld_str = " ".join(c.to_html() for c in meld)
             html.append(f"<p>Computer meld: {meld_str}</p>")
-    html.append(f"<p>Top of discard pile: {top_discard}</p>")
+    td_display = top_discard.to_html() if top_discard else "None"
+    html.append(f"<p>Top of discard pile: {td_display}</p>")
     html.append(f"<p>Cards left in deck: {deck_count}</p>")
     if message:
         html.append(f"<p>{message}</p>")
@@ -77,7 +78,7 @@ def html_page(message=""):
         if AWAITING_DISCARD:
             html.append("<p>Select a card to discard:</p>")
             for card in HUMAN.hand.cards:
-                html.append(f'<a href="/discard?card={card}">{card}</a> ')
+                html.append(f'<a href="/discard?card={card}">{card.to_html()}</a> ')
         elif DECISION_PENDING:
             if HUMAN.hand.is_gin():
                 html.append('<p><a href="/gin">Gin</a></p>')
@@ -88,13 +89,13 @@ def html_page(message=""):
             html.append("<p>Draw a card:</p>")
             html.append('<a href="/draw?source=deck">Deck</a> ')
             if GAME.discard_pile:
-                html.append(f'<a href="/draw?source=discard">Discard ({top_discard})</a>')
+                html.append(f'<a href="/draw?source=discard">Discard ({top_discard.to_html()})</a>')
         # Meld options
         melds = possible_melds(HUMAN.hand)
         if melds:
             html.append("<p>Lay down a meld:</p>")
             for meld in melds:
-                label = " ".join(str(c) for c in meld)
+                label = " ".join(c.to_html() for c in meld)
                 param = "-".join(str(c) for c in meld)
                 html.append(f'<a href="/meld?cards={param}">{label}</a><br>')
     else:


### PR DESCRIPTION
## Summary
- add `colored()` and `to_html()` helpers in `Card`
- allow `Hand` and CLI game to show ANSI colored text
- colorize card display in the web UI

## Testing
- `python3 -m py_compile gin_rummy.py random_player.py web_ui.py`
- `python3 gin_rummy.py`

------
https://chatgpt.com/codex/tasks/task_e_684d42edc5588332a0e41ffcf17378b3