### PR TITLE
Fix discard links truncated

### DIFF
--- a/web_ui.py
+++ b/web_ui.py
@@ -78,7 +78,7 @@ def html_page(message=""):
         if AWAITING_DISCARD:
             html.append("<p>Select a card to discard:</p>")
             for card in HUMAN.hand.cards:
-                html.append(f'<a href="/discard?card={card}">{card.to_html()}</a> ')
+                html.append(f'<a href="/discard?card={card}">{card.to_html()}</a>')
         elif DECISION_PENDING:
             if HUMAN.hand.is_gin():
                 html.append('<p><a href="/gin">Gin</a></p>')
@@ -103,7 +103,7 @@ def html_page(message=""):
 
     html.append('<p><a href="/reset">Restart</a></p>')
     html.append("</body></html>")
-    return "".join(html).encode("utf-8")
+    return "\n".join(html).encode("utf-8")
 
 
 def application(environ, start_response):


### PR DESCRIPTION
## Summary
- ensure each discard link is output on its own line
- join generated HTML with newline separators to avoid extremely long lines

## Testing
- `python3 -m py_compile web_ui.py gin_rummy.py random_player.py`

------
https://chatgpt.com/codex/tasks/task_e_684d4443aaa48332bcbfa70568cd7431